### PR TITLE
Handle line-end comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,15 @@ Returns an array of leading comments. Each comment must start with `#`.
 
 Extends [Psych::Nodes::Node](https://docs.ruby-lang.org/en/3.1/Psych/Nodes/Node.html).
 
+### `Psych::Nodes::Node#line_end_comment` -> `String`
+
+Returns `nil` or a `String` starting with `#` that contains any comment at the end of a line.
+
+Extends [Psych::Nodes::Node](https://docs.ruby-lang.org/en/3.1/Psych/Nodes/Node.html).
+
 ### `Psych::Nodes::Node#trailing_comments` -> `Array<String>`
 
-Returns an array of leading comments. Each comment must start with `#`.
+Returns an array of trailing comments. Each comment must start with `#`.
 
 Extends [Psych::Nodes::Node](https://docs.ruby-lang.org/en/3.1/Psych/Nodes/Node.html).
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Returns an array of leading comments. Each comment must start with `#`.
 
 Extends [Psych::Nodes::Node](https://docs.ruby-lang.org/en/3.1/Psych/Nodes/Node.html).
 
-### `Psych::Nodes::Node#line_end_comment` -> `String`
+### `Psych::Nodes::Node#line_end_comments` -> `Array<String>`
 
-Returns `nil` or a `String` starting with `#` that contains any comment at the end of a line.
+Returns either `[]` or an array containing any comments (starting with `#`) that appear at the end of a line.
 
 Extends [Psych::Nodes::Node](https://docs.ruby-lang.org/en/3.1/Psych/Nodes/Node.html).
 

--- a/lib/psych/comments/emitter.rb
+++ b/lib/psych/comments/emitter.rb
@@ -131,7 +131,7 @@ module Psych
           else
             print stringify_adjust_scalar(node, INDENT * @indent)
           end
-          emit_comment(node.line_end_comment) if node.line_end_comment
+          node.line_end_comments.each(&method(:emit_comment))
         when Psych::Nodes::Mapping
           set_flow(flow?(node)) do
             if @flow
@@ -149,7 +149,7 @@ module Psych
                 cont = true
               end
               print "}"
-              emit_comment(node.line_end_comment) if node.line_end_comment
+              node.line_end_comments.each(&method(:emit_comment))
             else
               newline!
               node.children.each_slice(2) do |(key, value)|
@@ -181,7 +181,7 @@ module Psych
                 cont = true
               end
               print "]"
-              emit_comment(node.line_end_comment) if node.line_end_comment
+              node.line_end_comments.each(&method(:emit_comment))
             else
               newline!
               node.children.each do |subnode|

--- a/lib/psych/comments/emitter.rb
+++ b/lib/psych/comments/emitter.rb
@@ -131,7 +131,10 @@ module Psych
           else
             print stringify_adjust_scalar(node, INDENT * @indent)
           end
-          node.line_end_comments.each(&method(:emit_comment))
+          node.line_end_comments.each do |comment|
+            print " "
+            emit_comment(comment)
+          end
         when Psych::Nodes::Mapping
           set_flow(flow?(node)) do
             if @flow
@@ -149,7 +152,10 @@ module Psych
                 cont = true
               end
               print "}"
-              node.line_end_comments.each(&method(:emit_comment))
+              node.line_end_comments.each do |comment|
+                print " "
+                emit_comment(comment)
+              end
             else
               newline!
               node.children.each_slice(2) do |(key, value)|
@@ -181,7 +187,10 @@ module Psych
                 cont = true
               end
               print "]"
-              node.line_end_comments.each(&method(:emit_comment))
+              node.line_end_comments.each do |comment|
+                print " "
+                emit_comment(comment)
+              end
             else
               newline!
               node.children.each do |subnode|
@@ -240,7 +249,7 @@ module Psych
       end
 
       def emit_comment(comment)
-        unless /\A\s*#[^\r\n]*\z/.match?(comment)
+        unless /\A#[^\r\n]*\z/.match?(comment)
           raise ArgumentError, "Invalid comment: #{comment.inspect}"
         end
         print comment

--- a/lib/psych/comments/emitter.rb
+++ b/lib/psych/comments/emitter.rb
@@ -131,6 +131,7 @@ module Psych
           else
             print stringify_adjust_scalar(node, INDENT * @indent)
           end
+          emit_comment(node.line_end_comment) if node.line_end_comment
         when Psych::Nodes::Mapping
           set_flow(flow?(node)) do
             if @flow
@@ -148,6 +149,7 @@ module Psych
                 cont = true
               end
               print "}"
+              emit_comment(node.line_end_comment) if node.line_end_comment
             else
               newline!
               node.children.each_slice(2) do |(key, value)|
@@ -179,6 +181,7 @@ module Psych
                 cont = true
               end
               print "]"
+              emit_comment(node.line_end_comment) if node.line_end_comment
             else
               newline!
               node.children.each do |subnode|
@@ -237,7 +240,7 @@ module Psych
       end
 
       def emit_comment(comment)
-        unless /\A#[^\r\n]*\z/.match?(comment)
+        unless /\A\s*#[^\r\n]*\z/.match?(comment)
           raise ArgumentError, "Invalid comment: #{comment.inspect}"
         end
         print comment

--- a/lib/psych/comments/node_ext.rb
+++ b/lib/psych/comments/node_ext.rb
@@ -5,7 +5,9 @@ class Psych::Nodes::Node
     @leading_comments ||= []
   end
 
-  attr_accessor :line_end_comment
+  def line_end_comments
+    @line_end_comments ||= []
+  end
 
   def trailing_comments
     @trailing_comments ||= []
@@ -13,6 +15,6 @@ class Psych::Nodes::Node
 
   alias end_column_without_comment end_column
   def end_column
-    end_column_without_comment + (line_end_comment&.length || 0)
+    end_column_without_comment + (line_end_comments[0]&.length || 0)
   end
 end

--- a/lib/psych/comments/node_ext.rb
+++ b/lib/psych/comments/node_ext.rb
@@ -5,7 +5,14 @@ class Psych::Nodes::Node
     @leading_comments ||= []
   end
 
+  attr_accessor :line_end_comment
+
   def trailing_comments
     @trailing_comments ||= []
+  end
+
+  alias end_column_without_comment end_column
+  def end_column
+    end_column_without_comment + (line_end_comment&.length || 0)
   end
 end

--- a/lib/psych/comments/parsing.rb
+++ b/lib/psych/comments/parsing.rb
@@ -47,7 +47,7 @@ module Psych
         when Psych::Nodes::Scalar, Psych::Nodes::Alias
           node.leading_comments.push(*read_comments(node.start_line, node.start_column))
           rest_of_line = sublines(node.end_line, node.end_column, node.end_line, -1)
-          node.line_end_comments << rest_of_line if rest_of_line =~ /^\s+#/
+          node.line_end_comments << rest_of_line.lstrip if rest_of_line =~ /^\s+#/
           @last = [node.end_line, node.end_column]
         when Psych::Nodes::Sequence, Psych::Nodes::Mapping
           has_delim = /[\[{]/.match?(char_at(node.start_line, node.start_column))
@@ -61,7 +61,7 @@ module Psych
           if has_delim
             rest_of_line = sublines(node.end_line, node.end_column, node.end_line, -1)
             if rest_of_line && rest_of_line =~ /^\s+#/
-              node.line_end_comments << rest_of_line
+              node.line_end_comments << rest_of_line.lstrip
               @last = [node.end_line, node.end_column]
             end
 

--- a/lib/psych/comments/parsing.rb
+++ b/lib/psych/comments/parsing.rb
@@ -47,7 +47,7 @@ module Psych
         when Psych::Nodes::Scalar, Psych::Nodes::Alias
           node.leading_comments.push(*read_comments(node.start_line, node.start_column))
           rest_of_line = sublines(node.end_line, node.end_column, node.end_line, -1)
-          node.line_end_comment = rest_of_line if rest_of_line =~ /^\s+#/
+          node.line_end_comments << rest_of_line if rest_of_line =~ /^\s+#/
           @last = [node.end_line, node.end_column]
         when Psych::Nodes::Sequence, Psych::Nodes::Mapping
           has_delim = /[\[{]/.match?(char_at(node.start_line, node.start_column))
@@ -61,7 +61,7 @@ module Psych
           if has_delim
             rest_of_line = sublines(node.end_line, node.end_column, node.end_line, -1)
             if rest_of_line && rest_of_line =~ /^\s+#/
-              node.line_end_comment = rest_of_line
+              node.line_end_comments << rest_of_line
               @last = [node.end_line, node.end_column]
             end
 

--- a/spec/emitter/example2-in.yml
+++ b/spec/emitter/example2-in.yml
@@ -7,7 +7,8 @@
   bar: baz
 - - 1
   - 2
-#foo3
+- foo: [1, 2, 3] # foo3
+#foo4
 - foo: bar
-- #foo3
+- #foo5
   foo: bar

--- a/spec/emitter/example2-out-wc.yml
+++ b/spec/emitter/example2-out-wc.yml
@@ -5,5 +5,6 @@
   bar: baz
 - - 1
   - 2
+- foo: [1, 2, 3]
 - foo: bar
 - foo: bar

--- a/spec/emitter/example2-out.yml
+++ b/spec/emitter/example2-out.yml
@@ -1,6 +1,5 @@
 # foo
-- foo
-# foo2
+- foo # foo2
 # foo
 - foo
 - foo: bar
@@ -8,7 +7,8 @@
   bar: baz
 - - 1
   - 2
-#foo3
+- foo: [1, 2, 3] # foo3
+#foo4
 - foo: bar
-- #foo3
+- #foo5
   foo: bar

--- a/spec/emitter/example3-in.yml
+++ b/spec/emitter/example3-in.yml
@@ -1,5 +1,5 @@
-- &x "foo"
-- *x
+- &x "foo" # line 1
+- *x # line 2
 - &y
   foo: bar
 - *y

--- a/spec/emitter/example3-out.yml
+++ b/spec/emitter/example3-out.yml
@@ -1,5 +1,5 @@
-- &x "foo"
-- *x
+- &x "foo" # line 1
+- *x # line 2
 - &y
   foo: bar
 - *y

--- a/spec/emitter/example4-in.yml
+++ b/spec/emitter/example4-in.yml
@@ -1,4 +1,4 @@
-- []
-- [1, 2]
-- {}
-- { foo: bar }
+- [] # line 1
+- [1, 2] # line 2
+- {} # line 3
+- { foo: bar } # line 4

--- a/spec/emitter/example4-out.yml
+++ b/spec/emitter/example4-out.yml
@@ -1,4 +1,4 @@
-- []
-- [1, 2]
-- {}
-- {foo: bar}
+- [] # line 1
+- [1, 2] # line 2
+- {} # line 3
+- {foo: bar} # line 4

--- a/spec/emitter/example5-out.yml
+++ b/spec/emitter/example5-out.yml
@@ -3,8 +3,7 @@ foo:
   bar: baz
   bar2:
     # test
-    foo: foo
-    #testtest
+    foo: foo #testtest
     # test
     bar: bar
   bar3:

--- a/spec/parsing_spec.rb
+++ b/spec/parsing_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Parsing" do
       YAML
       expect(ast.root).to be_a(Psych::Nodes::Sequence)
       expect(ast.root.children[0].leading_comments).to eq(["# foo"])
-      expect(ast.root.children[0].line_end_comment).to eq(" # end1")
+      expect(ast.root.children[0].line_end_comments).to eq([" # end1"])
       expect(ast.root.children[1].leading_comments).to eq(["# bar"])
       expect(ast.root.children[2].leading_comments).to eq(["# baz-a"])
     end

--- a/spec/parsing_spec.rb
+++ b/spec/parsing_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Parsing" do
       YAML
       expect(ast.root).to be_a(Psych::Nodes::Sequence)
       expect(ast.root.children[0].leading_comments).to eq(["# foo"])
-      expect(ast.root.children[0].line_end_comments).to eq([" # end1"])
+      expect(ast.root.children[0].line_end_comments).to eq(["# end1"])
       expect(ast.root.children[1].leading_comments).to eq(["# bar"])
       expect(ast.root.children[2].leading_comments).to eq(["# baz-a"])
     end

--- a/spec/parsing_spec.rb
+++ b/spec/parsing_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Parsing" do
     it "attaches comments to sequence elements" do
       ast = Psych::Comments.parse(<<~YAML)
         # foo
-        - foo1
+        - foo1 # end1
         - # bar
           bar2
         # baz-a
@@ -68,6 +68,7 @@ RSpec.describe "Parsing" do
       YAML
       expect(ast.root).to be_a(Psych::Nodes::Sequence)
       expect(ast.root.children[0].leading_comments).to eq(["# foo"])
+      expect(ast.root.children[0].line_end_comment).to eq(" # end1")
       expect(ast.root.children[1].leading_comments).to eq(["# bar"])
       expect(ast.root.children[2].leading_comments).to eq(["# baz-a"])
     end


### PR DESCRIPTION
Allows `psych-comments` to accurately around-trip comments that fall the same line as values — such as

```yaml
fruits:
- apples
- bananas
- tomatoes # requires some explanation
```
