### PR TITLE
add the ability to update leading and trailing comments

### DIFF
--- a/lib/psych/comments/node_ext.rb
+++ b/lib/psych/comments/node_ext.rb
@@ -8,4 +8,12 @@ class Psych::Nodes::Node
   def trailing_comments
     @trailing_comments ||= []
   end
+
+  def leading_comments=(comments)
+    @leading_comments = Array(comments)
+  end
+
+  def trailing_comments=(comments)
+    @trailing_comments = Array(comments)
+  end
 end

--- a/spec/node_ext_spec.rb
+++ b/spec/node_ext_spec.rb
@@ -8,12 +8,36 @@ RSpec.describe Psych::Nodes::Node do
       node = Psych::Nodes::Scalar.new("foo")
       expect(node.leading_comments).to eq([])
     end
+
+    it "can be set with an array of comments" do
+      node = Psych::Nodes::Scalar.new("foo")
+      node.leading_comments = ["# Comment 1", "# Comment 2"]
+      expect(node.leading_comments).to eq(["# Comment 1", "# Comment 2"])
+    end
+
+    it "wraps non-array values in an array" do
+      node = Psych::Nodes::Scalar.new("foo")
+      node.leading_comments = "# Single comment"
+      expect(node.leading_comments).to eq(["# Single comment"])
+    end
   end
 
   describe "#trailing_comments" do
     it "has an array" do
       node = Psych::Nodes::Scalar.new("foo")
       expect(node.trailing_comments).to eq([])
+    end
+
+    it "can be set with an array of comments" do
+      node = Psych::Nodes::Scalar.new("foo")
+      node.trailing_comments = ["# Comment 1", "# Comment 2"]
+      expect(node.trailing_comments).to eq(["# Comment 1", "# Comment 2"])
+    end
+
+    it "wraps non-array values in an array" do
+      node = Psych::Nodes::Scalar.new("foo")
+      node.trailing_comments = "# Single comment"
+      expect(node.trailing_comments).to eq(["# Single comment"])
     end
   end
 end


### PR DESCRIPTION
## Why

Thanks for this gem it is very helpful. At [RubyVideo](https://github.com/adrienpoly/rubyvideo) we manipulate lot's of yml files and being able to mutate them while preserving comment is great.

We encountered cases where we also would need to update current comments. 

## What

This PR add setters for the leading and trailing comments 