### PR TITLE
update ruby versions matrix in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0.2
+          - 3.2
+          - 3.3
+          - 3.4
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Why

RUby 3.0 is EOL. This PR updates the CI matrix to run agains 3.2, 3.3, 3.4 Ruby versions

## What
