### PR TITLE
fix frozen string literal warnings

### DIFF
--- a/lib/psych/comments/emitter.rb
+++ b/lib/psych/comments/emitter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Psych
   module Comments
     module NodeUtils
@@ -64,7 +66,8 @@ module Psych
     class Emitter
       include NodeUtils
 
-      INDENT = "  "
+      INDENT = "  ".freeze
+      SPACE = " ".freeze
 
       DEFAULT_TAGMAP = {
         '!' => '!',
@@ -74,7 +77,7 @@ module Psych
       attr_reader :out
 
       def initialize
-        @out = ""
+        @out = String.new
         @state = :init
         @indent = 0
         @flow = false
@@ -85,7 +88,7 @@ module Psych
       def print(text)
         case @state
         when :word_end
-          @out << " "
+          @out << SPACE
         when :line_start
           @out << INDENT * @indent
         end

--- a/lib/psych/comments/parsing.rb
+++ b/lib/psych/comments/parsing.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Psych
   module Comments
     class Analyzer


### PR DESCRIPTION
## Why

I had this warning in Ruby 3.4

```
lib/psych/comments/emitter.rb:93: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

## What

This PR adds a missing magic comment and replace the string initializer with String.new

